### PR TITLE
Base-Functionality for the Extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "keystrokemanager",
       "version": "0.0.1",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
@@ -1776,6 +1779,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -3791,6 +3802,11 @@
           }
         }
       }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:keystrokemanager.helloWorld"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "keystrokemanager.helloWorld",
-        "title": "Hello World"
+        "command": "keystrokemanager.showTotalKeystrokes",
+        "title": "Keystrokes: Show total"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       {
         "command": "keystrokemanager.showTotalKeystrokes",
         "title": "Keystrokes: Show total"
+      },
+      {
+        "command": "keystrokemanager.mostOftenPressedKeys",
+        "title": "Keystrokes: Show most often pressed Keys"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -34,16 +34,19 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.71.0",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "16.x",
+    "@types/vscode": "^1.71.0",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
+    "@vscode/test-electron": "^2.1.5",
     "eslint": "^8.20.0",
     "glob": "^8.0.3",
     "mocha": "^10.0.0",
-    "typescript": "^4.7.4",
-    "@vscode/test-electron": "^2.1.5"
+    "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "moment": "^2.29.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "keystrokemanager.showTotalKeystrokes",
-        "title": "Keystrokes: Show total"
+        "command": "keystrokemanager.showKeystrokeCountAnalytics",
+        "title": "Keystrokes: Show Count-Analytics"
       },
       {
         "command": "keystrokemanager.mostOftenPressedKeys",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,13 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const showKeystrokeCountAnalyticsCommandId = 'keystrokemanager.showKeystrokeCountAnalytics';
 	subscriptions.push(vscode.commands.registerCommand(showKeystrokeCountAnalyticsCommandId, () => {
 		const map = amountOfKeystrokesInTimespanMap;
-		const message = `You collected so far ${map.get('total')?.keystrokeCount} keystrokes in total. ${map.get('year')?.keystrokeCount} of them this year, ${map.get('month')?.keystrokeCount} this month, ${map.get('week')?.keystrokeCount} this week, ${map.get('day')?.keystrokeCount} today, ${map.get('hour')?.keystrokeCount} this hour and ${map.get('minute')?.keystrokeCount} this minute!`;
+		const message = `You collected so far ${map.get('total')?.keystrokeCount} keystrokes in total.
+						 ${map.get('year')?.keystrokeCount} of them this year, 
+						 ${map.get('month')?.keystrokeCount} this month, 
+						 ${map.get('week')?.keystrokeCount} this week, 
+						 ${map.get('day')?.keystrokeCount} today, 
+						 ${map.get('hour')?.keystrokeCount} this hour and 
+						 ${map.get('minute')?.keystrokeCount} this minute!`;
 
 		vscode.window.showInformationMessage(`😊 ${getPraisingWord()}! ${message}`);
 	}));
@@ -102,7 +108,7 @@ function getMostOftenPressedKeys(): Map<string, number> {
 }
 
 function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
-	const messageBeginning = new String('You pressed ');
+	const messageBeginning = new String('You pressed');
 	let result = messageBeginning;
 
 	// @todo: beautify this code-piece!!! disgusting!
@@ -114,9 +120,10 @@ function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
 	let placement = 1;
 	
 	keyMap.forEach((value, key, map) => {
-		const placementLine = new String(`${placementIcons.get(placement++)} '${key}' ${value} times  `);
+		const placementLine = new String(` ${placementIcons.get(placement++)} '${key}' ${value} times`);
 		result += placementLine.toString();
 	});
+	result += '!';
 
 	return result.toString();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,9 @@
+import { prependListener } from 'process';
 import * as vscode from 'vscode';
 
 let statusBarItem: vscode.StatusBarItem;
 let totalKeystrokes = 0;
+let pressedKeyMap = new Map<string, number>();
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const commandId = 'keystrokemanager.showTotalKeystrokes';
@@ -23,5 +25,9 @@ function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 	if(event && event.contentChanges) {
 		totalKeystrokes++;
 		statusBarItem.text = `Keystrokes: ${totalKeystrokes}`;
+		
+		const pressedKey = event.contentChanges[0].text;
+		const prevCount = pressedKeyMap.get(pressedKey) ?? 0;
+		pressedKeyMap.set(pressedKey, prevCount + 1);
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,8 +42,8 @@ let amountOfKeystrokesInTimespanMap = new Map<string, KeystrokeData>([
 ]);
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
-	const showTotalKeystrokesCommandId = 'keystrokemanager.showTotalKeystrokes';
-	subscriptions.push(vscode.commands.registerCommand(showTotalKeystrokesCommandId, () => {
+	const showKeystrokecountAnalyticsCommandId = 'keystrokemanager.showKeystrokecountAnalytics';
+	subscriptions.push(vscode.commands.registerCommand(showKeystrokecountAnalyticsCommandId, () => {
 		vscode.window.showInformationMessage(`😊 ${getPraisingWord()}! You typed ${amountOfKeystrokesInTimespanMap.get('total')} characters already!`);
 	}));
 
@@ -57,7 +57,7 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	
 	const ITEM_PRIORITY = 101;
 	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, ITEM_PRIORITY);
-	statusBarItem.command = showTotalKeystrokesCommandId;
+	statusBarItem.command = showKeystrokecountAnalyticsCommandId;
 	statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${amountOfKeystrokesInTimespanMap.get('total')}`;
 	statusBarItem.tooltip = 'Select Timespan';
 	statusBarItem.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
-import { prependListener } from 'process';
 import * as vscode from 'vscode';
+
+const KEYBOARD_ICON = '$(keyboard)';
 
 let statusBarItem: vscode.StatusBarItem;
 let totalKeystrokes = -1; // -1 instead of 0, because otherwise it starts with 2, when one key was pressed
@@ -22,7 +23,7 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const ITEM_PRIORITY = 101;
 	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, ITEM_PRIORITY);
 	statusBarItem.command = showTotalKeystrokesCommandId;
-	statusBarItem.text = `Keystrokes: ${totalKeystrokes + 1}`;
+	statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${totalKeystrokes + 1}`;
 	statusBarItem.show();
 	
 	subscriptions.push(statusBarItem);
@@ -33,7 +34,7 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 	if(event && event.contentChanges) {
 		totalKeystrokes++;
-		statusBarItem.text = `Keystrokes: ${totalKeystrokes}`;
+		statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${totalKeystrokes}`;
 		
 		collectPressedKeys(event);
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,9 @@ import * as vscode from 'vscode';
 import * as moment from 'moment';
 
 const KEYBOARD_ICON = '$(keyboard)';
+const FIRST_PLACE_ICON = '🥇';
+const SECOND_PLACE_ICON = '🥈';
+const THIRD_PLACE_ICON = '🥉';
 const KEYSTROKE_DEFAULT_VALUE = 0;
 
 /// general @todos:
@@ -101,9 +104,9 @@ function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
 
 	// @todo: beautify this code-piece!!! disgusting!
 	const placementIcons = new Map<number, string>([
-		[1, '🥇'],
-		[2, '🥈'],
-		[3, '🥉'],
+		[1, FIRST_PLACE_ICON],
+		[2, SECOND_PLACE_ICON],
+		[3, THIRD_PLACE_ICON],
 	]);
 	let placement = 1;
 	

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ let pressedKeyMap = new Map<string, number>();
 export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const showTotalKeystrokesCommandId = 'keystrokemanager.showTotalKeystrokes';
 	subscriptions.push(vscode.commands.registerCommand(showTotalKeystrokesCommandId, () => {
-		vscode.window.showInformationMessage(`Total Keystrokes: ${totalKeystrokes}`);
+		vscode.window.showInformationMessage(`😊 ${getPraisingWord()} You typed ${totalKeystrokes} characters already!`);
 	}));
 
 	const mostOftenPressedKeysCommandId = 'keystrokemanager.mostOftenPressedKeys';
@@ -72,4 +72,9 @@ function getMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
 	});
 
 	return result.toString();
+}
+
+function getPraisingWord(): string {
+	const words = ['Awesome!', 'Wonderful!', 'Great!', 'Fantastic!', 'Cool!'];
+	return words[Math.floor(Math.random() * words.length)];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 let statusBarItem: vscode.StatusBarItem;
-let totalKeystrokes : number = 0;
+let totalKeystrokes = 0;
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const commandId = 'keystrokemanager.showTotalKeystrokes';
@@ -14,12 +14,14 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	statusBarItem.command = commandId;
 	subscriptions.push(statusBarItem);
 
-	subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateStatusBarItem));
+	subscriptions.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => updateStatusBarItem(event)));
 
-	updateStatusBarItem();
+	statusBarItem.show();
 }
 
-function updateStatusBarItem(): void {
-	statusBarItem.text = `Keystrokes: ${++totalKeystrokes}`;
-	statusBarItem.show();
+function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
+	if(event && event.contentChanges) {
+		totalKeystrokes++;
+		statusBarItem.text = `Keystrokes: ${totalKeystrokes}`;
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,40 @@
 import * as vscode from 'vscode';
+import * as moment from 'moment';
 
 const KEYBOARD_ICON = '$(keyboard)';
+const KEYSTROKE_DEFAULT_VALUE = 0;
+
+class Test {
+	date: Date;
+	keystrokeCount: number;
+
+	constructor(date: Date, keystrokeCount: number) {
+		this.date = date;
+		this. keystrokeCount = keystrokeCount;
+	}
+}
 
 let statusBarItem: vscode.StatusBarItem;
-let totalKeystrokes = 0; // -1 instead of 0, because otherwise it starts with 2, when one key was pressed
+let totalKeystrokes = KEYSTROKE_DEFAULT_VALUE; // -1 instead of 0, because otherwise it starts with 2, when one key was pressed
 let pressedKeyMap = new Map<string, number>();
+// @todo: add totalKeystrokes in this map
+let amountOfKeystrokesInTimespanMap = new Map<string, Test>([
+	['second', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['minute', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['hour', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['day', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['week', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['month', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	['year', new Test(new Date(), KEYSTROKE_DEFAULT_VALUE)],
+	// ['total', KEYSTROKE_DEFAULT_VALUE],
+]);
+
+let hourTimer = new Date();
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
 	const showTotalKeystrokesCommandId = 'keystrokemanager.showTotalKeystrokes';
 	subscriptions.push(vscode.commands.registerCommand(showTotalKeystrokesCommandId, () => {
-		vscode.window.showInformationMessage(`😊 ${getPraisingWord()} You typed ${totalKeystrokes} characters already!`);
+		vscode.window.showInformationMessage(`😊 ${getPraisingWord()}! You typed ${totalKeystrokes} characters already!`);
 	}));
 
 	const mostOftenPressedKeysCommandId = 'keystrokemanager.mostOftenPressedKeys';
@@ -26,7 +51,6 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${totalKeystrokes}`;
 	statusBarItem.tooltip = 'Select Timespan';
 	statusBarItem.show();
-	
 	subscriptions.push(statusBarItem);
 
 	subscriptions.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => updateStatusBarItem(event)));
@@ -40,6 +64,15 @@ function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 	   event.contentChanges[0].text !== undefined) {
 		totalKeystrokes++;
 		statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${totalKeystrokes}`;
+
+		amountOfKeystrokesInTimespanMap.forEach((value, key, map) => {
+			map.set(key, new Test(value.date, value.keystrokeCount + 1));
+
+			if(isTimespanAgo(value.date, key)) {
+				map.set(key, new Test(new Date(), KEYSTROKE_DEFAULT_VALUE));
+			}
+			console.log(`${key}: ${value.keystrokeCount}; `);
+		});
 		
 		collectPressedKey(event);
 	}
@@ -47,23 +80,22 @@ function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 
 function collectPressedKey(event: vscode.TextDocumentChangeEvent): void {
 	const pressedKey = event.contentChanges[0].text;
-	// 0, as default value, when key was not pressed yet
-	const prevCount = pressedKeyMap.get(pressedKey) ?? 0;
+	const prevCount = pressedKeyMap.get(pressedKey) ?? KEYSTROKE_DEFAULT_VALUE;
 
 	pressedKeyMap.set(pressedKey, prevCount + 1);
 }
 
 function getMostOftenPressedKeys(): Map<string, number> {
-	let pressedKeysSortedDescending = new Map([...pressedKeyMap].sort((prev, curr) => prev[1] - curr[1]).reverse());
+	const pressedKeysSortedDescending = new Map([...pressedKeyMap].sort((prev, curr) => prev[1] - curr[1]).reverse());
 
 	const targetSize = 3;
-	let mostOftenPressedKeys = new Map([...pressedKeysSortedDescending].slice(0, targetSize));
+	const mostOftenPressedKeys = new Map([...pressedKeysSortedDescending].slice(0, targetSize));
 
 	return mostOftenPressedKeys;
 }
 
 function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
-	const messageBeginning = new String('Most often pressed keys: ');
+	const messageBeginning = new String('You pressed ');
 	let result = messageBeginning;
 
 	const placementIcons = new Map<number, string>([
@@ -74,7 +106,7 @@ function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
 	let placement = 1;
 	
 	keyMap.forEach((value, key, map) => {
-		const placementLine = new String(`${placementIcons.get(placement++)} '${key}' pressed ${value} times  `);
+		const placementLine = new String(`${placementIcons.get(placement++)} '${key}' ${value} times  `);
 		result += placementLine.toString();
 	});
 
@@ -82,6 +114,14 @@ function printMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
 }
 
 function getPraisingWord(): string {
-	const words = ['Awesome!', 'Wonderful!', 'Great!', 'Fantastic!', 'Cool!'];
-	return words[Math.floor(Math.random() * words.length)];
+	const WORDS = ['Awesome', 'Wonderful', 'Great', 'Fantastic', 'Cool'];
+	return WORDS[Math.floor(Math.random() * WORDS.length)];
+}
+
+function isTimespanAgo(date: Date, timespan: string) {
+	// here it is everytime 1 hour, 1 day, etc.
+	const AMOUNT_OF_TIMESPAN = 1;
+	const timeSpanConvertedIntoCorrectFormat: moment.unitOfTime.DurationConstructor = timespan as moment.DurationInputArg2; 
+	
+	return moment(date).isBefore(moment().subtract(AMOUNT_OF_TIMESPAN, timeSpanConvertedIntoCorrectFormat));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,6 @@ const YEAR_AS_MILLISECONDS = MONTH_AS_MILLISECONDS * 12;
 // - write read-me
 // - write changelog
 // - add cicd to project on github
-// - add keystrokes per min / hour, etc. feature
 // - add feature to display the whole analytics of which keys were pressed in a json-file or something like this
 // - add feature to the keystroke-counts, etc.
 
@@ -98,9 +97,9 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	setInterval(() => resetOneAmountOfKeystrokes('hour'), HOUR_AS_MILLISECONDS);
 	setInterval(() => resetOneAmountOfKeystrokes('day'), DAY_AS_MILLISECONDS);
 	setInterval(() => resetOneAmountOfKeystrokes('week'), WEEK_AS_MILLISECONDS);
-	setInterval(() => resetOneAmountOfKeystrokes('month'), MONTH_AS_MILLISECONDS);
-	setInterval(() => resetOneAmountOfKeystrokes('year'), YEAR_AS_MILLISECONDS);
-
+	setLongInterval(() => resetOneAmountOfKeystrokes('month'), MONTH_AS_MILLISECONDS);
+	setLongInterval(() => resetOneAmountOfKeystrokes('year'), YEAR_AS_MILLISECONDS);
+	
 	subscriptions.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => updateStatusBarItem(event)));
 }
 
@@ -159,6 +158,23 @@ function getPraisingWord(): string {
 	return WORDS[Math.floor(Math.random() * WORDS.length)];
 }
 
+const setLongInterval = (callback: any, timeout: number) => {
+    let count = 0;
+    const MAX_32_BIT_SIGNED = 2147483647;
+    const maxIterations = timeout / MAX_32_BIT_SIGNED;
+
+    const onInterval = () => {
+        ++count;
+        if (count > maxIterations) {
+            count = 0;
+            callback();
+        }
+    };
+
+    return setInterval(onInterval, Math.min(timeout, MAX_32_BIT_SIGNED));
+};
+
 function resetOneAmountOfKeystrokes(key: string): void {
+	console.log("here: " + key);
 	amountsOfKeystrokes.set(key, KEYSTROKE_DEFAULT_VALUE);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,9 +42,12 @@ let amountOfKeystrokesInTimespanMap = new Map<string, KeystrokeData>([
 ]);
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
-	const showKeystrokecountAnalyticsCommandId = 'keystrokemanager.showKeystrokecountAnalytics';
-	subscriptions.push(vscode.commands.registerCommand(showKeystrokecountAnalyticsCommandId, () => {
-		vscode.window.showInformationMessage(`😊 ${getPraisingWord()}! You typed ${amountOfKeystrokesInTimespanMap.get('total')} characters already!`);
+	const showKeystrokeCountAnalyticsCommandId = 'keystrokemanager.showKeystrokeCountAnalytics';
+	subscriptions.push(vscode.commands.registerCommand(showKeystrokeCountAnalyticsCommandId, () => {
+		const map = amountOfKeystrokesInTimespanMap;
+		const message = `You collected so far ${map.get('total')?.keystrokeCount} keystrokes in total. ${map.get('year')?.keystrokeCount} of them this year, ${map.get('month')?.keystrokeCount} this month, ${map.get('week')?.keystrokeCount} this week, ${map.get('day')?.keystrokeCount} today, ${map.get('hour')?.keystrokeCount} this hour and ${map.get('minute')?.keystrokeCount} this minute!`;
+
+		vscode.window.showInformationMessage(`😊 ${getPraisingWord()}! ${message}`);
 	}));
 
 	const mostOftenPressedKeysCommandId = 'keystrokemanager.mostOftenPressedKeys';
@@ -57,8 +60,8 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	
 	const ITEM_PRIORITY = 101;
 	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, ITEM_PRIORITY);
-	statusBarItem.command = showKeystrokecountAnalyticsCommandId;
-	statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${amountOfKeystrokesInTimespanMap.get('total')}`;
+	statusBarItem.command = showKeystrokeCountAnalyticsCommandId;
+	statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${amountOfKeystrokesInTimespanMap.get('total')?.keystrokeCount}`;
 	statusBarItem.tooltip = 'Select Timespan';
 	statusBarItem.show();
 	subscriptions.push(statusBarItem);
@@ -76,7 +79,7 @@ function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 			isTimespanAgo(value.date, key) && key !== 'total' ? map.set(key, new KeystrokeData(new Date(), KEYSTROKE_DEFAULT_VALUE))
 															  : map.set(key, new KeystrokeData(value.date, value.keystrokeCount + 1))
 		);  
-		statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${amountOfKeystrokesInTimespanMap.get('total')}`;
+		statusBarItem.text = `${KEYBOARD_ICON} Keystrokes: ${amountOfKeystrokesInTimespanMap.get('total')?.keystrokeCount}`;
 
 		collectPressedKey(event);
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,23 +2,32 @@ import { prependListener } from 'process';
 import * as vscode from 'vscode';
 
 let statusBarItem: vscode.StatusBarItem;
-let totalKeystrokes = 0;
+let totalKeystrokes = -1; // -1 instead of 0, because otherwise it starts with 2, when one key was pressed
 let pressedKeyMap = new Map<string, number>();
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
-	const commandId = 'keystrokemanager.showTotalKeystrokes';
-	subscriptions.push(vscode.commands.registerCommand(commandId, () => {
+	const showTotalKeystrokesCommandId = 'keystrokemanager.showTotalKeystrokes';
+	subscriptions.push(vscode.commands.registerCommand(showTotalKeystrokesCommandId, () => {
 		vscode.window.showInformationMessage(`Total Keystrokes: ${totalKeystrokes}`);
 	}));
+
+	const mostOftenPressedKeysCommandId = 'keystrokemanager.mostOftenPressedKeys';
+	subscriptions.push(vscode.commands.registerCommand(mostOftenPressedKeysCommandId, () => {
+		const mostOftenPressedKeys = getMostOftenPressedKeys();
+		const message = getMostOftenPressedKeysMessage(mostOftenPressedKeys);
+
+		vscode.window.showInformationMessage(message);
+	}));
 	
-	const ITEM_PRIORITY = 1000;
+	const ITEM_PRIORITY = 101;
 	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, ITEM_PRIORITY);
-	statusBarItem.command = commandId;
+	statusBarItem.command = showTotalKeystrokesCommandId;
+	statusBarItem.text = `Keystrokes: ${totalKeystrokes + 1}`;
+	statusBarItem.show();
+	
 	subscriptions.push(statusBarItem);
 
 	subscriptions.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => updateStatusBarItem(event)));
-
-	statusBarItem.show();
 }
 
 function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
@@ -26,8 +35,41 @@ function updateStatusBarItem(event: vscode.TextDocumentChangeEvent): void {
 		totalKeystrokes++;
 		statusBarItem.text = `Keystrokes: ${totalKeystrokes}`;
 		
-		const pressedKey = event.contentChanges[0].text;
-		const prevCount = pressedKeyMap.get(pressedKey) ?? 0;
-		pressedKeyMap.set(pressedKey, prevCount + 1);
+		collectPressedKeys(event);
 	}
+}
+
+function collectPressedKeys(event: vscode.TextDocumentChangeEvent): void {
+	const pressedKey = event.contentChanges[0].text;
+	const prevCount = pressedKeyMap.get(pressedKey) ?? 0;
+
+	pressedKeyMap.set(pressedKey, prevCount + 1);
+}
+
+function getMostOftenPressedKeys(): Map<string, number> {
+	let pressedKeysSortedDescending = new Map([...pressedKeyMap].sort((prev, curr) => prev[1] - curr[1]).reverse());
+
+	const targetSize = 3;
+	let mostOftenPressedKeys = new Map([...pressedKeysSortedDescending].slice(0, targetSize));
+
+	return mostOftenPressedKeys;
+}
+
+function getMostOftenPressedKeysMessage(keyMap: Map<string, number>): string {
+	const messageBeginning = new String('Most often pressed keys: ');
+	let result = messageBeginning;
+
+	const placementIcons = new Map<number, string>([
+		[1, '🥇'],
+		[2, '🥈'],
+		[3, '🥉'],
+	]);
+	let placement = 1;
+	
+	keyMap.forEach((value, key, map) => {
+		const placementLine = new String(`${placementIcons.get(placement++)} '${key}' pressed ${value} times  `);
+		result += placementLine.toString();
+	});
+
+	return result.toString();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,25 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+let statusBarItem: vscode.StatusBarItem;
+let totalKeystrokes : number = 0;
+
+export function activate({ subscriptions }: vscode.ExtensionContext) {
+	const commandId = 'keystrokemanager.showTotalKeystrokes';
+	subscriptions.push(vscode.commands.registerCommand(commandId, () => {
+		vscode.window.showInformationMessage(`Total Keystrokes: ${totalKeystrokes}`);
+	}));
 	
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "keystrokemanager" is now active!');
+	const ITEM_PRIORITY = 1000;
+	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, ITEM_PRIORITY);
+	statusBarItem.command = commandId;
+	subscriptions.push(statusBarItem);
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('keystrokemanager.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from KeystrokeManager!');
-	});
+	subscriptions.push(vscode.window.onDidChangeTextEditorSelection(updateStatusBarItem));
 
-	context.subscriptions.push(disposable);
+	updateStatusBarItem();
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() {}
+function updateStatusBarItem(): void {
+	statusBarItem.text = `Keystrokes: ${++totalKeystrokes}`;
+	statusBarItem.show();
+}


### PR DESCRIPTION
# Summary
* add keystroke-counter
* counter works with different time-spans (second, minute, hour, day, week, month, year, total)
* resetting counter, when timespan is over
* wpm-counter, that updates every second
* analytics about which keys were pressed the most

Examples: 
![image](https://user-images.githubusercontent.com/78447003/192107874-ec10f095-3cd2-4dc7-b7c4-329da1ba02ed.png)
![image](https://user-images.githubusercontent.com/78447003/192107910-730aa7c7-419f-438b-b9ce-00b7981f92c6.png)
![image](https://user-images.githubusercontent.com/78447003/192107904-f0b01ca5-78d9-4236-8624-f403e8095d5b.png)
![image](https://user-images.githubusercontent.com/78447003/192111752-81ddd646-5ad0-4c01-b972-0068c1ebf125.png)